### PR TITLE
Refactor the base configuration

### DIFF
--- a/lua/bastibast/init.lua
+++ b/lua/bastibast/init.lua
@@ -4,15 +4,9 @@ require("bastibast.remap")
 local augroup = vim.api.nvim_create_augroup
 local autocmd = vim.api.nvim_create_autocmd
 
-local ThePrimeagenGroup = augroup('ThePrimeagen', {})
-
 local yank_group = augroup('HighlightYank', {})
 
 local editor_startup = augroup('EditorStartup', {})
-
-function R(name)
-    require("plenary.reload").reload_module(name)
-end
 
 autocmd('TextYankPost', {
     group = yank_group,
@@ -25,14 +19,7 @@ autocmd('TextYankPost', {
     end,
 })
 
-autocmd({"BufWritePre"}, {
-    group = ThePrimeagenGroup,
-    pattern = "*",
-    command = [[%s/\s\+$//e]],
-})
-
 autocmd({"VimEnter"}, {
     group = editor_startup,
-    pattern = "*",
-    command = [[Neotree]],
+    command = [[Neotree toggle current reveal_force_cwd]],
 })

--- a/lua/bastibast/packer.lua
+++ b/lua/bastibast/packer.lua
@@ -70,7 +70,5 @@ use {
       -- "3rd/image.nvim", -- Optional image support in preview window: See `# Preview Mode` for more information
     }
   }
-  vim.cmd([[nnoremap \ :Neotree reveal<cr>]])
-
 end)
 

--- a/lua/bastibast/remap.lua
+++ b/lua/bastibast/remap.lua
@@ -1,5 +1,5 @@
 vim.g.mapleader = " "
-vim.keymap.set("n", "<leader>pv", vim.cmd.Ex)
+vim.keymap.set("n", "<leader>e", vim.cmd.Ex)
 
 vim.keymap.set("v", "J", ":m '>+1<CR>gv=gv")
 vim.keymap.set("v", "K", ":m '<-2<CR>gv=gv")
@@ -11,28 +11,13 @@ vim.keymap.set("n", "<C-u>", "<C-u>zz")
 vim.keymap.set("n", "n", "nzzzv")
 vim.keymap.set("n", "N", "Nzzzv")
 
-vim.keymap.set("n", "<leader>vwm", function()
-    require("vim-with-me").StartVimWithMe()
-end)
-vim.keymap.set("n", "<leader>svwm", function()
-    require("vim-with-me").StopVimWithMe()
-end)
-
--- greatest remap ever
 vim.keymap.set("x", "<leader>p", [["_dP]])
 
--- next greatest remap ever : asbjornHaland
-vim.keymap.set({"n", "v"}, "<leader>y", [["+y]])
+vim.keymap.set({ "n", "v" }, "<leader>y", [["+y]])
 vim.keymap.set("n", "<leader>Y", [["+Y]])
-
-vim.keymap.set({"n", "v"}, "<leader>d", [["_d]])
-
--- This is going to get me cancelled
-vim.keymap.set("i", "<C-c>", "<Esc>")
+vim.keymap.set({ "n", "v" }, "<leader>d", [["_d]])
 
 vim.keymap.set("n", "Q", "<nop>")
-vim.keymap.set("n", "<C-f>", "<cmd>silent !tmux neww tmux-sessionizer<CR>")
-vim.keymap.set("n", "<leader>f", vim.lsp.buf.format)
 
 vim.keymap.set("n", "<C-k>", "<cmd>cnext<CR>zz")
 vim.keymap.set("n", "<C-j>", "<cmd>cprev<CR>zz")
@@ -41,4 +26,3 @@ vim.keymap.set("n", "<leader>j", "<cmd>lprev<CR>zz")
 
 vim.keymap.set("n", "<leader>s", [[:%s/\<<C-r><C-w>\>/<C-r><C-w>/gI<Left><Left><Left>]])
 vim.keymap.set("n", "<leader>x", "<cmd>!chmod +x %<CR>", { silent = true })
-

--- a/lua/bastibast/set.lua
+++ b/lua/bastibast/set.lua
@@ -25,6 +25,3 @@ vim.opt.signcolumn = "yes"
 vim.opt.isfname:append("@-@")
 
 vim.opt.updatetime = 50
-
-vim.cmd('let g:netrw_bufsettings = "noma nomod nu nobl nowrap ro"')
-vim.cmd('let g:netrw_liststyle= 3')


### PR DESCRIPTION
- Remove useless key mappings
- Remove useless autocmd
- Improve the Neotree command so it opens only one window, with the correct path requested when calling neovim.
- Remove commands for newtree as we're using neotree